### PR TITLE
DPE-529 Make alphabetical sorting of fields in Zendesk ticket optional

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -83,6 +83,7 @@ def zendesk_action_payload():
             'service_name': 'Market Access',
             'form_url': '/some/form/',
             'ingress_url': 'https://www.example.com',
+            'sort_fields_alphabetically': True
         },
     }
 

--- a/submission/helpers.py
+++ b/submission/helpers.py
@@ -35,9 +35,11 @@ class ZendeskClient:
         return self.client.users.create_or_update(zendesk_user)
 
     def create_ticket(self, subject, payload, zendesk_user, service_name):
+        sort_fields_alphabetically = payload.get('_sort_fields_alphabetically', True)
+        items = sorted(payload.items()) if sort_fields_alphabetically else payload.items()
         description = [
             '{0}: {1}'.format(key.title().replace('_', ' '), value)
-            for key, value in sorted(payload.items())
+            for key, value in items
             if not key.title().startswith('_')
         ]
         ticket = Ticket(

--- a/submission/serializers.py
+++ b/submission/serializers.py
@@ -35,6 +35,7 @@ class ZendeskActionSerializer(serializers.Serializer):
             'payload': {
                 **submission.data,
                 'ingress_url': submission.meta.get('ingress_url'),
+                '_sort_fields_alphabetically': submission.meta.get('sort_fields_alphabetically')
             }
         }
         return cls(data=data, *args, **kwargs)

--- a/submission/tests/test_serializers.py
+++ b/submission/tests/test_serializers.py
@@ -189,10 +189,15 @@ def test_email_action_serializer_from_submission(email_submission):
     }
 
 
+@pytest.mark.parametrize("sort_fields_alphabetically, expected_serialized_sort_alphabetically", [
+    (True, True),
+    (False, False)
+])
 @pytest.mark.django_db
 def test_zendesk_action_serializer_from_submission(
-    zendesk_submission, settings
+    zendesk_submission, settings, sort_fields_alphabetically, expected_serialized_sort_alphabetically
 ):
+    zendesk_submission.meta['sort_fields_alphabetically'] = sort_fields_alphabetically
     serializer = serializers.ZendeskActionSerializer.from_submission(
         zendesk_submission
     )
@@ -204,6 +209,7 @@ def test_zendesk_action_serializer_from_submission(
         'payload': {
             **zendesk_submission.data,
             'ingress_url': zendesk_submission.meta['ingress_url'],
+            '_sort_fields_alphabetically': expected_serialized_sort_alphabetically
         },
         'subdomain': settings.ZENDESK_SUBDOMAIN_DEFAULT,
         'service_name': zendesk_submission.meta['service_name'],

--- a/submission/tests/test_views.py
+++ b/submission/tests/test_views.py
@@ -303,6 +303,7 @@ def test_zendesk_action(
     expected_payload = {
         **zendesk_action_payload['data'],
         'ingress_url': zendesk_action_payload['meta']['ingress_url'],
+        '_sort_fields_alphabetically': zendesk_action_payload['meta']['sort_fields_alphabetically'],
     }
 
     assert response.status_code == 201


### PR DESCRIPTION
This PR amends the current approach to creating a Zendesk ticket so that sorting of fields by alphabetical order is parameterized. This is necessary as alphabetical ordering of fields may render the ticket difficult to read, for example when 'first_name' is not displayed immediately prior to 'last_name' (below).

<img width="167" alt="Screenshot 2023-10-19 at 16 18 46" src="https://github.com/uktrade/directory-forms-api/assets/1638245/fcb1c384-fb89-4f07-9887-ea9f8438fdde">

### Workflow

- [x] Ticket exists in [Jira](https://uktrade.atlassian.net/jira/software/projects/DPE/boards/397/backlog?selectedIssue=DPE-529)
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

Refer to [this draft PR](https://github.com/uktrade/great-cms/pull/2659/files) for Great-CMS for an example of calling.

1. Use version directory-forms-api-client version >= 7.3.0
2. Set parameter 'sort_fields_alphabetically' when instantiating the ZendeskAction. 
3. Submit a form
4. Review in Zendesk staging

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
