### PR TITLE
Bump cryptography to 41.0.7 and django to 4.1.13

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ directory-healthcheck==3.1.2
 django-cryptography==1.1
 zenpy==1.1.10
 celery[redis]>=5.2.2
-cryptography>=41.0.4
+cryptography>=41.0.7
 notifications-python-client==8.0.0
 directory-components==39.1.3
 urllib3==2.0.7

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ zenpy==1.1.10
 celery[redis]>=5.2.2
 cryptography>=41.0.7
 notifications-python-client==8.0.0
-directory-components==39.1.3
+directory-components==39.1.4
 urllib3==2.0.7
 django-ratelimit==2.0
 django-redis==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ cryptography==41.0.7
     # via
     #   -r requirements.in
     #   django-cryptography
-directory-components==39.1.3
+directory-components==39.1.4
     # via -r requirements.in
 directory-constants==23.1.0
     # via directory-components

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ click-repl==0.2.0
     # via celery
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements.in
     #   django-cryptography

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -58,7 +58,7 @@ cryptography==41.0.7
     # via
     #   -r requirements.in
     #   django-cryptography
-directory-components==39.1.3
+directory-components==39.1.4
     # via -r requirements.in
 directory-constants==23.1.0
     # via directory-components

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -54,7 +54,7 @@ coverage==5.1
     #   pytest-cov
 cron-descriptor==1.4.0
     # via django-celery-beat
-cryptography==41.0.4
+cryptography==41.0.7
     # via
     #   -r requirements.in
     #   django-cryptography


### PR DESCRIPTION
Bump cryptography to 41.0.7 and django to 4.1.13

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-1685
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.


### Housekeeping

- [x] Upgraded any vulnerable dependencies.
- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
