### PR TITLE
Upgrade Zenpy to 2.0.46.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ requests[security]==2.31.0
 sigauth==5.2.3
 directory-healthcheck==3.3
 django-cryptography==1.1
-zenpy==1.1.10
+zenpy==2.0.46
 celery[redis]>=5.2.2
 cryptography>=41.0.7
 notifications-python-client==8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ cachetools==5.3.0
 celery[redis]==5.2.7
     # via
     #   -r requirements.in
-    #   celery
     #   django-celery-beat
 certifi==2023.7.22
     # via
@@ -154,6 +153,7 @@ pytz==2023.3
     #   celery
     #   django-timezone-field
     #   djangorestframework
+    #   zenpy
 pyyaml==6.0
     # via drf-spectacular
 redis==4.4.4
@@ -164,7 +164,6 @@ requests[security]==2.31.0
     # via
     #   -r requirements.in
     #   notifications-python-client
-    #   requests
     #   requests-oauthlib
     #   zenpy
 requests-oauthlib==1.3.1
@@ -180,6 +179,7 @@ six==1.16.0
     #   jsonschema
     #   mohawk
     #   python-dateutil
+    #   zenpy
 soupsieve==2.4
     # via beautifulsoup4
 sqlparse==0.4.4
@@ -207,7 +207,7 @@ wcwidth==0.2.6
     # via prompt-toolkit
 whitenoise==6.4.0
     # via -r requirements.in
-zenpy==1.1.10
+zenpy==2.0.46
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -23,7 +23,6 @@ cachetools==4.1.0
 celery[redis]==5.2.3
     # via
     #   -r requirements.in
-    #   celery
     #   django-celery-beat
 certifi==2023.7.22
     # via
@@ -204,6 +203,7 @@ pytz==2021.3
     #   celery
     #   django-timezone-field
     #   djangorestframework
+    #   zenpy
 pyyaml==6.0
     # via drf-spectacular
 redis==4.4.4
@@ -215,7 +215,6 @@ requests[security]==2.31.0
     #   -r requirements.in
     #   codecov
     #   notifications-python-client
-    #   requests
     #   requests-mock
     #   requests-oauthlib
     #   zenpy
@@ -238,6 +237,7 @@ six==1.14.0
     #   pyrsistent
     #   python-dateutil
     #   requests-mock
+    #   zenpy
 soupsieve==2.0
     # via beautifulsoup4
 sqlparse==0.4.4
@@ -273,7 +273,7 @@ wcwidth==0.1.9
     # via prompt-toolkit
 whitenoise==6.4.0
     # via -r requirements.in
-zenpy==1.1.10
+zenpy==2.0.46
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This is necessary because the ticketing replacement microservice for the switch from Zendesk to Halo requires the `ZENPY_FORCE_NETLOC` setting which was introduced in Zenpy 2.0.18.

(Please add a sentence or two explaining the context of this PR. Reviewers can go to the ticket for detail.)
CONTEXT: This changeset adds/removes/updates [summary of feature/area/code] so that [summary of benefit].

_Tick or delete as appropriate:_

### Workflow

- [✅] A clear/description pull request messaged added.

### Housekeeping

- [✅ ] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
