### PR TITLE
Updated bulk email API V2 endpoint to accept bulk email data.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -127,6 +127,7 @@ def gov_notify_email_action_payload():
 def gov_notify_bulk_email_action_payload():
     return {
             'template_id': '1234',
+            'action_name': constants.ACTION_NAME_GOV_NOTIFY_BULK_EMAIL,
             'bulk_email_entries': [
                 {'name': 'one', 'email_address': 'one@example.com'},
                 {'name': 'two', 'email_address': 'two@example.com'},

--- a/conftest.py
+++ b/conftest.py
@@ -127,8 +127,11 @@ def gov_notify_email_action_payload():
 def gov_notify_bulk_email_action_payload():
     return {
             'template_id': '1234',
-            'email_addresses': ['notify-user1@example.com', 'notify-user2@example.com', 'notify-user3@example.com'],
-            'personalisation': {},
+            'bulk_email_entries': [
+                {'name': 'one', 'email_address': 'one@example.com'},
+                {'name': 'two', 'email_address': 'two@example.com'},
+                {'name': 'three', 'email_address': 'three@example.com'}
+            ],
             'email_reply_to_id': '5678',
     }
 

--- a/submission/constants.py
+++ b/submission/constants.py
@@ -1,6 +1,7 @@
 ACTION_NAME_ZENDESK = 'zendesk'
 ACTION_NAME_EMAIL = 'email'
 ACTION_NAME_GOV_NOTIFY_EMAIL = 'gov-notify-email'
+ACTION_NAME_GOV_NOTIFY_BULK_EMAIL = 'gov-notify-bulk-email'
 ACTION_NAME_GOV_NOTIFY_LETTER = 'gov-notify-letter'
 ACTION_NAME_PARDOT = 'pardot'
 ACTION_NAME_SAVE_ONLY_IN_DB = 'save-only-in-db'

--- a/submission/helpers.py
+++ b/submission/helpers.py
@@ -136,6 +136,8 @@ def get_sender_email_address(submission_meta):
         return submission_meta['reply_to'][0]
     elif action_name == constants.ACTION_NAME_GOV_NOTIFY_EMAIL:
         return submission_meta['email_address']
+    elif action_name == constants.ACTION_NAME_GOV_NOTIFY_BULK_EMAIL:
+        return None
     elif action_name == constants.ACTION_NAME_PARDOT:
         return None
     elif action_name == constants.ACTION_NAME_GOV_NOTIFY_LETTER:
@@ -149,6 +151,8 @@ def get_recipient_email_address(submission_meta):
         service_name = submission_meta.get('service_name')
         return f'{sub_domain}:{service_name}'
     elif action_name == constants.ACTION_NAME_GOV_NOTIFY_EMAIL:
+        return submission_meta['email_address']
+    elif action_name == constants.ACTION_NAME_GOV_NOTIFY_BULK_EMAIL:
         return submission_meta['email_address']
     elif action_name == constants.ACTION_NAME_EMAIL:
         return ','.join(submission_meta['recipients'])

--- a/submission/serializers.py
+++ b/submission/serializers.py
@@ -66,15 +66,27 @@ class GovNotifyEmailSerializer(serializers.Serializer):
         return cls(data=data, *args, **kwargs)
 
 
+class GovNotifyBulkEmailEntrySerializer(serializers.Serializer):
+    """
+    Serializer for bulk_email_entries, which is a list of dictionaries submitted to GovNotifyBulkEmailSerializer.
+    These dictionaries are free form as the contain email template data that is unique to each gov.uk email template
+    all we are checking for is the presence of a recipient email address, which is mandatory.
+    """
+
+    email_address = serializers.CharField()
+
+
 class GovNotifyBulkEmailSerializer(serializers.Serializer):
     """
-    This serializer accepts a list of email addresses 1>n, in order
-    to send the email to multiple recipients.
+    This serializer accepts a list of email data 1>n, in order
+    to send email to multiple recipients.
+
+    bulk_email_entries contains a list of dicts of personalised email data. it MUST contain an 'email'
+    key for each entry in order to pass serialisation.
     """
 
     template_id = serializers.CharField()
-    email_addresses = serializers.ListField()
-    personalisation = serializers.DictField()
+    bulk_email_entries = serializers.ListField(child=GovNotifyBulkEmailEntrySerializer())
     email_reply_to_id = serializers.CharField(required=False)
 
 

--- a/submission/tests/test_helpers.py
+++ b/submission/tests/test_helpers.py
@@ -322,34 +322,33 @@ def test_send_pardor(mock_post):
     )
 
 
-def test_get_sender_email_address_email_action(email_action_payload):
-    email = helpers.get_sender_email_address(email_action_payload['meta'])
-    assert email == 'email-user@example.com'
+class TestGetSenderEmailAddresses:
+    @pytest.mark.parametrize("action_payload,expected",
+                             [('email_action_payload', 'email-user@example.com'),
+                              ('zendesk_action_payload', 'zendesk-user@example.com'),
+                              ('gov_notify_email_action_payload', 'erp+testform@jhgk.com'),
+                              ('pardot_action_payload', None)])
+    def test_get_sender_email_addresses(self, action_payload, expected, request):
+        assert helpers.get_sender_email_address(request.getfixturevalue(action_payload)['meta']) == expected
 
+    def test_get_sender_email_address_notify_action(self, gov_notify_email_action_payload):
+        del gov_notify_email_action_payload['meta']['sender']
+        email = helpers.get_sender_email_address(gov_notify_email_action_payload['meta'])
+        assert email == 'notify-user@example.com'
 
-def test_get_sender_email_address_zendesk_action(zendesk_action_payload):
-    email = helpers.get_sender_email_address(zendesk_action_payload['meta'])
-    assert email == 'zendesk-user@example.com'
-
-
-def test_get_sender_email_address_notify_action(gov_notify_email_action_payload):
-    del gov_notify_email_action_payload['meta']['sender']
-    email = helpers.get_sender_email_address(gov_notify_email_action_payload['meta'])
-    assert email == 'notify-user@example.com'
-
-
-def test_get_sender_email_address_pardot_action(pardot_action_payload):
-    email = helpers.get_sender_email_address(pardot_action_payload['meta'])
-    assert email is None
-
-
-def test_get_sender_email_address_sender(gov_notify_email_action_payload):
-    email = helpers.get_sender_email_address(gov_notify_email_action_payload['meta'])
-    assert email == 'erp+testform@jhgk.com'
+    def test_get_sender_gov_notify_bulk_email_action_payload(self, gov_notify_bulk_email_action_payload):
+        email = helpers.get_sender_email_address(gov_notify_bulk_email_action_payload)
+        assert email is None
 
 
 def test_get_recipient_email_address_notify_action(gov_notify_email_action_payload):
     email = helpers.get_recipient_email_address(gov_notify_email_action_payload['meta'])
+    assert email == 'notify-user@example.com'
+
+
+def test_get_recipient_email_address_bulk_notify_action(gov_notify_bulk_email_action_payload):
+    gov_notify_bulk_email_action_payload['email_address'] = 'notify-user@example.com'
+    email = helpers.get_recipient_email_address(gov_notify_bulk_email_action_payload)
     assert email == 'notify-user@example.com'
 
 

--- a/submission/tests/test_views.py
+++ b/submission/tests/test_views.py
@@ -501,7 +501,6 @@ class TestBulkGovNotifyEmail:
         )
 
         assert models.Submission.objects.count() == 3
-
         assert response.status_code == 201, response.json()
 
     @pytest.mark.django_db
@@ -509,7 +508,23 @@ class TestBulkGovNotifyEmail:
         assert models.Submission.objects.count() == 0
 
         # Malform the data payload
-        del gov_notify_bulk_email_action_payload['email_addresses']
+        del gov_notify_bulk_email_action_payload['bulk_email_entries']
+
+        response = api_client.post(
+            reverse('api_v2:gov-notify-bulk-email'),
+            data=gov_notify_bulk_email_action_payload,
+            format='json'
+        )
+
+        assert models.Submission.objects.count() == 0
+        assert response.status_code == 400, response.json()
+
+    @pytest.mark.django_db
+    def test_gov_notify_bulk_email_action_fails_on_missing_email(self, api_client, gov_notify_bulk_email_action_payload):
+        assert models.Submission.objects.count() == 0
+
+        # Malform the data payload by removing a single email entry
+        del gov_notify_bulk_email_action_payload['bulk_email_entries'][0]['email_address']
 
         response = api_client.post(
             reverse('api_v2:gov-notify-bulk-email'),

--- a/submission/tests/test_views.py
+++ b/submission/tests/test_views.py
@@ -520,7 +520,8 @@ class TestBulkGovNotifyEmail:
         assert response.status_code == 400, response.json()
 
     @pytest.mark.django_db
-    def test_gov_notify_bulk_email_action_fails_on_missing_email(self, api_client, gov_notify_bulk_email_action_payload):
+    def test_gov_notify_bulk_email_action_fails_on_missing_email(self, api_client,
+                                                                 gov_notify_bulk_email_action_payload):
         assert models.Submission.objects.count() == 0
 
         # Malform the data payload by removing a single email entry


### PR DESCRIPTION
This PR updates the gov_notify_bulk_email endpoint so that it can process the new freeform template data submission from directory-forms-api-client.

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-69

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
